### PR TITLE
Fix Rakuten API indentation bug and add startup env preflight check

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,6 +108,16 @@ def safe_int(x: Any, default: int = 0) -> int:
     except Exception:
         return default
 
+
+
+def missing_required_envs() -> List[str]:
+    required = {
+        "RAKUTEN_APP_ID": RAKUTEN_APP_ID,
+        "SHEET_ID": SHEET_ID,
+        "GSPREAD_SERVICE_ACCOUNT_JSON_B64": GSPREAD_SERVICE_ACCOUNT_JSON_B64,
+    }
+    return [name for name, value in required.items() if not value]
+
 def discord_notify(title: str, lines: List[str]) -> None:
     if not DISCORD_WEBHOOK_URL:
         return
@@ -278,13 +288,13 @@ def rakuten_search_page(keyword: str, page: int, hits: int) -> List[Dict[str, An
         params["affiliateId"] = RAKUTEN_AFFILIATE_ID
 
     resp = requests.get(RAKUTEN_ENDPOINT, params=params, timeout=30)
-resp.raise_for_status()
+    resp.raise_for_status()
 
-data = resp.json()
+    data = resp.json()
 
-print("DEBUG http:", resp.status_code, "keys:", list(data.keys())[:10])
+    print("DEBUG http:", resp.status_code, "keys:", list(data.keys())[:10])
 
-        # formatVersion=2 style
+    # formatVersion=2 style
     if isinstance(data, dict) and data.get("items"):
         return data["items"]
 
@@ -421,6 +431,10 @@ def main():
     print("ACCESS_KEY len:", len(os.environ.get("RAKUTEN_ACCESS_KEY","")))
     print("APP_ID:", os.environ.get("RAKUTEN_APP_ID", "")[:6], "len=", len(os.environ.get("RAKUTEN_APP_ID","")))
     print("ENDPOINT:", RAKUTEN_ENDPOINT)
+
+    missing_envs = missing_required_envs()
+    if missing_envs:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing_envs)}")
     today = jst_today_str()
     yesterday = (jst_date() - timedelta(days=1)).isoformat()
 


### PR DESCRIPTION
### Motivation
- Restore runtime-parseability after an `IndentationError` in the Rakuten API response handling made the module fail at import/compile time.
- Make startup failures clearer by explicitly validating required secrets so CI or local runs fail fast with a helpful message.

### Description
- Fixed incorrect indentation in `rakuten_search_page` so `resp.raise_for_status()`, `resp.json()` and subsequent parsing run inside the function scope as intended.
- Added `missing_required_envs()` which checks `RAKUTEN_APP_ID`, `SHEET_ID`, and `GSPREAD_SERVICE_ACCOUNT_JSON_B64` for presence.
- Call the preflight check in `main()` and raise a clear `RuntimeError` listing missing environment variables if any are absent.
- Kept changes minimal and focused on restoring correct parsing and improving diagnostics without altering core pricing logic.

### Testing
- Reproduced original failure: `python -m py_compile main.py` previously failed with `IndentationError` and this was observed before the fix (reproduction successful).
- Static compile check: `python -m py_compile main.py` now succeeds (✅).
- Runtime smoke: `python main.py` now exits immediately with a clear `RuntimeError` listing missing envs (expected in this environment because `RAKUTEN_APP_ID`, `SHEET_ID`, and `GSPREAD_SERVICE_ACCOUNT_JSON_B64` are not set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a032be736483309df9f06f55daf27b)