### PR TITLE
Add observability for zero-result runs and STRICT_MODE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
+# protein-hunter
 
+## 0件時の考え方
+
+このジョブは楽天APIから取得した商品候補に対して、除外・重複排除・容量一致などのフィルタを適用してから `Price_History` に追記します。
+
+- `STRICT_MODE=true` の場合:
+  - append対象行数が `0` ならジョブを失敗終了します。
+  - 監視を厳格にしたい（=0件は異常とみなす）運用向けです。
+- `STRICT_MODE` が未設定/`false` の場合:
+  - append対象行数が `0` でもジョブは成功扱いです。
+  - ただし警告ログを出力し、調査可能にします。
+
+## デバッグ手順（fetched/appended が 0 のとき）
+
+1. **取得フェーズログを確認**
+   - `DEBUG fetch` に `api_total_count`（API上のヒット件数）と `fetched_items`（実際に取得した件数）が出ます。
+   - `api_total_count > 0` なのに `fetched_items = 0` の場合は、ページング・レスポンス構造・API制限を疑います。
+
+2. **フィルタ内訳ログを確認**
+   - `DEBUG filter` の `drop_counts` で、各段階の落ち件数が見えます。
+   - 主なキー:
+     - `missing_required_or_invalid_price`
+     - `excluded_keyword`
+     - `capacity_mismatch`
+     - `invalid_offer`
+     - `duplicate`
+     - `store_hits_limit`
+
+3. **書き込み直前の件数を確認**
+   - `DEBUG append: rows_to_append=N` が append直前の行数です。
+   - `N=0` の場合は、上記 `DEBUG filter` のどこで落ちたかを追います。
+
+4. **STRICT_MODE で失敗化して検知強化（必要時）**
+   - CI/Workflowで `STRICT_MODE=true` を設定すると、0件を失敗として即検知できます。
+
+## 主要な環境変数
+
+- `RAKUTEN_APP_ID`
+- `RAKUTEN_AFFILIATE_ID`（任意）
+- `SHEET_ID`
+- `GSPREAD_SERVICE_ACCOUNT_JSON_B64`
+- `STRICT_MODE`（任意、`true/false`）


### PR DESCRIPTION
### Motivation

- Make it possible to diagnose why runs produce `fetched=0` or `appended=0` by emitting detailed fetch and filter telemetry. 
- Provide an operational toggle to treat zero-appends as a hard failure for stricter monitoring (`STRICT_MODE`).

### Description

- Expose `api_total_count` from Rakuten responses by changing `rakuten_search_page` and `rakuten_search_multi_pages` to return `(items, total_count)` and log `DEBUG fetch` per canonical item with `api_total_count` and `fetched_items`.
- Add `classify_item_filter` and per-key `filter_drop_counts` to classify why items are dropped (e.g. `missing_required_or_invalid_price`, `excluded_keyword`, `capacity_mismatch`, `invalid_offer`, `duplicate`, `store_hits_limit`) and emit `DEBUG filter` with the counts.
- Emit `DEBUG append: rows_to_append=N` immediately before writing to `Price_History` and implement `STRICT_MODE` (env var) that raises when `N==0` if enabled, otherwise prints a warning.
- Update `README.md` with a “0件時の考え方” section and step-by-step debug guidance listing the new logs and environment variable (`STRICT_MODE`).

### Testing

- Ran `python -m py_compile main.py` to validate syntax and the changes compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a036562110833091e926b37a7c4103)