### PR TITLE
Add Hatena draft posting for TOP3 ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@
 - `SHEET_ID`
 - `GSPREAD_SERVICE_ACCOUNT_JSON_B64`
 - `STRICT_MODE`（任意、`true/false`）
+- `HATENA_ID`（任意、はてなブログBasic認証ユーザー）
+- `HATENA_API_KEY`（任意、はてなブログAPIキー）
+
+## はてなブログ下書き投稿
+
+ジョブ完了後、各 `canonical_id` の当日最安オファーを実質コストで並べ、TOP3ランキング記事を下書きで投稿します。
+
+- POST先: `https://blog.hatena.ne.jp/naoki1978/protein-hunter.hatenablog.com/atom/entry`
+- タイトル形式: `【プロテイン価格ランキング】YYYY-MM-DD`
+- 本文: TOP3ランキングMarkdown
+- 認証: Basic認証（`HATENA_ID` + `HATENA_API_KEY`）
+- 失敗時: エラーログを出力し、既存の価格収集処理は継続


### PR DESCRIPTION
### Motivation
- Automate publishing a TOP3 protein price ranking to Hatena Blog as a draft after the existing `protein-hunter` run so daily rankings are available without manual posting.
- Use Basic auth with existing environment-secret pattern and ensure posting failures do not break the price-collection pipeline.

### Description
- Added two new environment variables `HATENA_ID` and `HATENA_API_KEY` and a fixed Atom endpoint `HATENA_BLOG_ATOM_ENDPOINT` for posting drafts to Hatena Blog.
- Implemented `build_top3_markdown(best_offers: List[OfferRow])` to generate the TOP3 article body in Markdown including date, ranking, and per-offer details.
- Implemented `post_top3_to_hatena(markdown_body: str)` which builds an Atom XML entry (with XML-escaping via `xml.sax.saxutils.escape`), sets `<app:draft>yes</app:draft>`, sends it with Basic auth, and logs success or stack traces on failure without raising.
- Collected each canonical item's daily-best offer during the run, sorted by effective protein cost, and invoked the Markdown builder + Hatena poster after existing Sheets writes and Discord notifications; README updated with new env vars and posting behavior.

### Testing
- Compiled the modified module with `python -m py_compile main.py`, which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04309f1d08330a85bb9d17da82342)