### PR TITLE
Fix Hatena AtomPub endpoint assembly, add diagnostics for 404 and make notifications resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,23 @@
 - `STRICT_MODE`（任意、`true/false`）
 - `HATENA_ID`（任意、はてなブログBasic認証ユーザー）
 - `HATENA_API_KEY`（任意、はてなブログAPIキー）
+- `HATENA_BLOG_ID`（任意、ブログドメイン。例: `protain-hunter.hatenablog.com`）
 
 ## はてなブログ下書き投稿
 
 ジョブ完了後、各 `canonical_id` の当日最安オファーを実質コストで並べ、TOP3ランキング記事を下書きで投稿します。
 
-- POST先: `https://blog.hatena.ne.jp/naoki1978/protein-hunter.hatenablog.com/atom/entry`
+- Service Document: `https://blog.hatena.ne.jp/${HATENA_ID}/${HATENA_BLOG_ID}/atom`
+- POST先: `https://blog.hatena.ne.jp/${HATENA_ID}/${HATENA_BLOG_ID}/atom/entry`
 - タイトル形式: `【プロテイン価格ランキング】YYYY-MM-DD`
 - 本文: TOP3ランキングMarkdown
 - 認証: Basic認証（`HATENA_ID` + `HATENA_API_KEY`）
 - 失敗時: エラーログを出力し、既存の価格収集処理は継続
+
+### 設定例
+
+```env
+HATENA_ID=naoki1978
+HATENA_BLOG_ID=protain-hunter.hatenablog.com
+# HATENA_API_KEY=xxxxxxxx
+```


### PR DESCRIPTION
### Motivation

- The Hatena AtomPub target was a fixed/incorrect URL which can cause 404s when the blog id differs from the hardcoded value. 
- When posting fails with 404 we need more diagnostic info (service document and collection hrefs) to distinguish URL vs auth/permission issues without leaking secrets. 
- Discord webhook failures should not cause the run to fail or stop other notifications.

### Description

- Add `HATENA_BLOG_ID` env var and build AtomPub endpoints dynamically as `https://blog.hatena.ne.jp/{HATENA_ID}/{HATENA_BLOG_ID}/atom` and `/atom/entry` via `build_hatena_service_endpoint()` and `build_hatena_entry_endpoint()`.
- Improve Hatena error handling: on HTTP >=400 log `status code` and a preview of the response body (up to 500 chars) and, if 404, GET the service document (`/atom`) and log collection `href` values for triage using `log_hatena_service_document()` without printing secrets.
- Make Hatena posting failure non-fatal by returning on error so other processing continues, and wrap Discord sends in a try/except so webhook errors are logged but do not abort the run (`discord_notify()` now handles exceptions).
- Update `README.md` with `HATENA_BLOG_ID` description, service document/POST URL templates and a concrete example (`HATENA_ID=naoki1978`, `HATENA_BLOG_ID=protain-hunter.hatenablog.com`).

### Testing

- Ran `python -m py_compile main.py` and it succeeded (syntax check pass). 
- Attempted `python -m py_compile main.py README.md` which failed because `README.md` is not a Python file (expected), and the code change itself compiled fine. 
- Searched changed strings with `rg -n "HATENA_BLOG_ID|hatena.ne.jp|atom/entry|discord" main.py README.md` to validate the edits and found the updated occurrences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a04f9eb3f083309d29e61d023befc2)