### PR TITLE
Use Hatena AtomPub /entry endpoint and always-send Discord run summary

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,7 +22,6 @@ jobs:
         env:
           RAKUTEN_APP_ID: ${{ secrets.RAKUTEN_APP_ID }}
           RAKUTEN_AFFILIATE_ID: ${{ secrets.RAKUTEN_AFFILIATE_ID }}
-          RAKUTEN_ACCESS_KEY: ${{ secrets.RAKUTEN_ACCESS_KEY }}
           SHEET_ID: ${{ secrets.SHEET_ID }}
           GSPREAD_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.GSPREAD_SERVICE_ACCOUNT_JSON_B64 }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
### Motivation
- Ensure Hatena draft posts reliably use the official AtomPub entry endpoint built from `HATENA_ID` and `HATENA_BLOG_ID` and make failures diagnosable from CI logs. 
- Always send a run summary to Discord (including 0-change runs) and surface Hatena errors instead of silently swallowing them so the workflow operator is informed. 

### Description
- Build Hatena endpoints from env and POST to `https://blog.hatena.ne.jp/{HATENA_ID}/{HATENA_BLOG_ID}/atom/entry` via a new `build_hatena_entry_endpoint()` helper. 
- Refactor `post_top3_to_hatena` to return a `HatenaPostResult` dataclass with `ok`, `status_code`, `endpoint`, and `message`, and add logging of endpoint and HTTP status/body-preview for diagnostics. 
- Collect Hatena failures into `run_errors`, include Hatena result and any errors in a Discord summary that is always sent (`📊 Rakuten protein tracker summary`), and raise `RuntimeError` after notifying to fail the workflow when Hatena posting fails. 
- Keep per-item change notifications as before but ensure a summary is sent even when there are 0 change notifications. 
- Remove unused `RAKUTEN_ACCESS_KEY` from the GitHub Actions env in `.github/workflows/daily.yml`. 
- Secrets used remain: `HATENA_ID`, `HATENA_API_KEY`, `HATENA_BLOG_ID`, and `DISCORD_WEBHOOK_URL` (plus existing sheet and Rakuten secrets). 
- Files changed: `main.py`, `.github/workflows/daily.yml`.

### Testing
- `python -m py_compile main.py` succeeded. 
- Attempted to parse ` .github/workflows/daily.yml` in this environment but YAML parsing was not executed due to missing `yaml` module, so workflow YAML validation was not performed here. 
- Basic runtime checks (static compile) passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0516c46a8833088ee936bac3a4dec)