### PR TITLE
Improve Hatena blog ranking markdown formatting for readability

### DIFF
--- a/main.py
+++ b/main.py
@@ -170,29 +170,34 @@ def log_hatena_service_document(auth: Tuple[str, str], service_endpoint: str) ->
 
 def build_top3_markdown(best_offers: List[OfferRow]) -> str:
     lines = [
-        "# 今日のTOP3プロテイン価格ランキング",
+        f"## 🏆 今日のプロテイン価格ランキング – {jst_today_str()}",
         "",
-        f"- 集計日: {jst_today_str()}",
         f"- 基準: タンパク質1kgあたり実質コスト（価格 + 送料 - ポイント）",
         "",
     ]
 
     if not best_offers:
-        lines.append("本日のランキングは作成できませんでした（対象データなし）。")
+        lines.extend([
+            "### 本日のランキング結果",
+            "- 該当なし（対象データが見つかりませんでした）",
+        ])
         return "\n".join(lines)
 
+    rank_icons = {1: "🥇", 2: "🥈", 3: "🥉"}
     for i, offer in enumerate(best_offers[:3], 1):
+        rank_icon = rank_icons.get(i, "🏅")
         lines.extend(
             [
-                f"## {i}位: {offer.canonical_id}",
-                f"- ショップ: {offer.shop_name}",
-                f"- 実質コスト: **{offer.protein_cost:,.0f}円** / タンパク質1kg",
-                f"- 価格内訳: 本体 {offer.raw_price:,}円 + 送料 {offer.shipping_cost:,}円 / pt {offer.point_rate * 100:.1f}%",
-                f"- 商品名: {offer.item_name}",
-                f"- URL: {offer.item_url}",
+                f"### {rank_icon} 第{i}位：**{offer.item_name}**",
+                f"- 実質コスト：{offer.protein_cost:,.0f}円 / タンパク質1kg",
+                f"- 価格詳細：本体 {offer.raw_price:,}円 / 送料 {offer.shipping_cost:,}円 / ポイント {offer.point_rate * 100:.1f}%",
+                f"- ショップ：{offer.shop_name}",
+                f"- 🎯 リンク：👉 [楽天で商品を見る]({offer.item_url})",
                 "",
             ]
         )
+
+    lines.extend(["---", "", "※ このフォーマットははてなブログAtomPub投稿用です。"])
 
     return "\n".join(lines).strip()
 


### PR DESCRIPTION
### Motivation
- The existing Hatena AtomPub markdown contained long raw URLs and flat sections which made daily posts hard to read. 
- The goal is to present each product as a visually distinct section with prioritized, human-friendly fields. 
- The output must also explicitly handle the no-results case so posts never appear empty.

### Description
- Updated `build_top3_markdown` in `main.py` to use a dated top heading `## 🏆 今日のプロテイン価格ランキング – {jst_today_str()}` and keep the ranking criterion line. 
- Render each product as a `###` section with a rank icon (🥇/🥈/🥉) and bold product name, followed by bullet points showing effective cost, detailed price breakdown, shop, and a visible-link text. 
- Replaced raw URL output with a visible link `🎯 リンク：👉 [楽天で商品を見る](...)` to avoid long URL text in the body. 
- Added an explicit no-result block `### 本日のランキング結果` with `- 該当なし（対象データが見つかりませんでした）` and appended a footer note indicating the format is for Hatena AtomPub posts.

### Testing
- Ran `python -m py_compile main.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a052be247c83308d14b95100e838e5)