### PR TITLE
エクスプロージョン3kg向け 収益最大化投稿フローを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,21 @@ HATENA_ID=naoki1978
 HATENA_BLOG_ID=protain-hunter.hatenablog.com
 # HATENA_API_KEY=xxxxxxxx
 ```
+
+
+## 収益最大化モード（エクスプロージョン3kg専用）
+
+このジョブは `Master_List` から **エクスプロージョン3kg** のみを対象にして、毎回以下を実施します。
+
+- 前日比（円・％）を算出
+- 過去30日最安を判定
+- 価格変動レベルを3段階で分類
+  - `normal`
+  - `drop`（-3% or -300円）
+  - `big_drop`（-5% or -500円 or 30日最安）
+- レベル別CTAテンプレートを生成
+- X投稿文案を自動生成
+- はてな投稿用Markdownを自動生成
+- Discordに投稿案を通知
+
+過度な煽りは避けつつ、価格下落時の緊急性を明確に出す設計です。


### PR DESCRIPTION
### Motivation
- 楽天アフィリエイトの収益最大化のため、対象を「エクスプロージョン3kg」のみへ絞り、価格変動に応じた投稿案（X・はてな・Discord）を自動生成する機能を追加する目的です。 
- 前日比や過去30日最安の判定で緊急性を明確にしつつ過度な煽りを避ける運用ルールを組み込みます。 
- 投稿テンプレ（CTA）を価格変動レベルごとに切り替え、収益性の高いタイミングでの誘導を狙います。 

### Description
- 新しいデータモデル `PriceChangeReport` を追加して、前日比・差額・変動レベル・CTA・X文案・はてなMarkdownを集約しました。 
- `is_explosion_3kg_target` により `Master_List` を「エクスプロージョン3kg」のみフィルタし、該当が無ければ明示エラーで終了するようにしました。 
- 価格履歴から日次最安を取得する `read_price_history_daily_min` と、前日比/過去30日最安を評価して `normal/drop/big_drop` の3段階を返す `choose_level` / `cta_by_level` を実装しました。 
- `build_marketing_report` で X（旧Twitter）投稿文と Hatena 投稿用Markdown を生成し、実行時に各商品について Discord に投稿案を通知してはてな下書き投稿（AtomPub）も行うフローへと切り替えました。 
- README に「収益最大化モード（エクスプロージョン3kg専用）」の仕様を追記しました。 

### Testing
- `python -m py_compile main.py` による構文チェックを実行し成功しました。 
- 変更はローカルでファイル差分・静的検査（`rg`/`nl` 等の確認）を行い、コミットが作成済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d061c5b08330aeae568fcf8301c9)