### PR TITLE
Fix Hatena AtomPub markdown rendering metadata

### DIFF
--- a/main.py
+++ b/main.py
@@ -440,10 +440,11 @@ def post_top3_to_hatena(markdown_body: str) -> HatenaPostResult:
 
     title = f"【プロテイン価格ランキング】{jst_today_str()}"
     atom_xml = f"""<?xml version=\"1.0\" encoding=\"utf-8\"?>
-<entry xmlns=\"http://www.w3.org/2005/Atom\" xmlns:app=\"http://www.w3.org/2007/app\">
+<entry xmlns=\"http://www.w3.org/2005/Atom\" xmlns:app=\"http://www.w3.org/2007/app\" xmlns:hatena=\"http://www.hatena.ne.jp/info/xmlns#\">
   <title>{escape(title)}</title>
   <author><name>{escape(HATENA_ID)}</name></author>
-  <content type=\"text/x-markdown\">{escape(markdown_body)}</content>
+  <hatena:syntax>markdown</hatena:syntax>
+  <content type=\"text/plain\">{escape(markdown_body)}</content>
   <app:control>
     <app:draft>yes</app:draft>
   </app:control>


### PR DESCRIPTION
### Motivation
- Hatena blog posts were being displayed as literal Markdown because the Atom `<entry>` lacked Hatena-specific metadata indicating the body is Markdown.

### Description
- Add the Hatena XML namespace `xmlns:hatena="http://www.hatena.ne.jp/info/xmlns#"` to the Atom `<entry>` element in `main.py`.
- Insert `<hatena:syntax>markdown</hatena:syntax>` inside the `<entry>` to mark the content as Markdown and set the `<content>` to `type="text/plain"` as requested while leaving `build_marketing_report` output logic unchanged.
- Only `main.py` was modified to implement these metadata changes for AtomPub posting.

### Testing
- Ran `python -m py_compile main.py` which succeeded with no syntax errors, and verified the change set shows only `main.py` was modified using Git commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0deb477a48330be8fcf6bdbd1b1af)