### PR TITLE
Use named args for gspread worksheet.update to avoid deprecation

### DIFF
--- a/main.py
+++ b/main.py
@@ -652,7 +652,10 @@ def upsert_today_min(min_ws, date: str, cid: str, min_cost: float, min_shop: str
 
     updated_at = jst_now_iso()
     if target_row:
-        min_ws.update(f"C{target_row}:F{target_row}", [[str(min_cost), min_shop, min_url, updated_at]])
+        min_ws.update(
+            values=[[str(min_cost), min_shop, min_url, updated_at]],
+            range_name=f"C{target_row}:F{target_row}",
+        )
     else:
         min_ws.append_row([date, cid, str(min_cost), min_shop, min_url, updated_at], value_input_option="RAW")
 


### PR DESCRIPTION
### Motivation
- GitHub Actions のログに出ていた DeprecationWarning を解消し、将来の引数順変更で壊れないよう `worksheet.update()` 呼び出しを gspread の新シグネチャに合わせる。

### Description
- `main.py` の `upsert_today_min` 内の `min_ws.update(...)` を `values=[[...]], range_name="C{target_row}:F{target_row}"` の名前付き引数形式に変更して既存の更新範囲と値/型は維持し、"gspread update() の新しいシグネチャに合わせた" 修正とした。

### Testing
- `python -m py_compile main.py` を実行して成功し、`rg "\.update\(" -n` によりリポジトリ内の `.update(` 呼び出しが該当箇所のみで修正済みであることを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f0dbe08c8330ab1a5f4fd1a74dcc)