### PR TITLE
Normalize gspread worksheet update keyword arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -652,6 +652,7 @@ def upsert_today_min(min_ws, date: str, cid: str, min_cost: float, min_shop: str
 
     updated_at = jst_now_iso()
     if target_row:
+        # gspread warning対策: updateはキーワード引数(values/range_name)で統一する
         min_ws.update(
             values=[[str(min_cost), min_shop, min_url, updated_at]],
             range_name=f"C{target_row}:F{target_row}",


### PR DESCRIPTION
### Motivation
- Avoid gspread/GitHub Actions warnings by ensuring `worksheet.update` calls use explicit keyword arguments `values=` and `range_name=` consistently.

### Description
- Audited `main.py` for `update` usage and confirmed only one `min_ws.update(...)` call needed attention and already uses keyword args. 
- Added an inline comment explaining the `values=/range_name=` keyword-argument convention to make the intent explicit and suppress warnings.
- Did not change `batch_update` or `update_cell` usages because they are not present or not in scope.

### Testing
- Ran `rg -n "batch_update|update_cell|\.update\(" main.py` to verify update usage and it returned the expected single `min_ws.update` occurrence. 
- Ran `python -m py_compile main.py` and it succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f24e0e848330a42676263edb60c0)