### PR TITLE
Improve Rakuten image URL extraction and ensure high-res OfferRow images

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,22 +149,31 @@ def normalize_image_url(url: str) -> str:
 
 
 def pick_best_image_url(item: Dict[str, Any]) -> str:
+    def first_image_url(raw: Any) -> str:
+        if isinstance(raw, str):
+            return normalize_image_url(raw)
+        if isinstance(raw, dict):
+            for key in ("imageUrl", "itemImageUrl", "url"):
+                if raw.get(key):
+                    return normalize_image_url(str(raw.get(key, "")))
+            return ""
+        if isinstance(raw, list):
+            for elem in raw:
+                selected = first_image_url(elem)
+                if selected:
+                    return selected
+        return ""
 
-    medium_images = item.get("mediumImageUrls") or []
-    if isinstance(medium_images, list) and medium_images:
-        image = medium_images[0]
-        if isinstance(image, dict) and image.get("imageUrl"):
-            selected_url = normalize_image_url(str(image.get("imageUrl", "")))
-            if selected_url:
-                return selected_url
-
-    small_images = item.get("smallImageUrls") or []
-    if isinstance(small_images, list) and small_images:
-        image = small_images[0]
-        if isinstance(image, dict) and image.get("imageUrl"):
-            selected_url = normalize_image_url(str(image.get("imageUrl", "")))
-            if selected_url:
-                return selected_url
+    for key in (
+        "mediumImageUrls",
+        "smallImageUrls",
+        "imageUrl",
+        "itemImageUrl",
+        "itemImageUrls",
+    ):
+        selected_url = first_image_url(item.get(key))
+        if selected_url:
+            return selected_url
 
     return ""
 


### PR DESCRIPTION
### Motivation
- Some offers had empty `best_offer.image_url` despite the Rakuten API providing image candidates, causing the Hatena draft to show only a link instead of an inline hero image. 
- The goal is to always populate `OfferRow.image_url` when an image is available and prefer a high-resolution URL so the Hatena hero image reliably appears. 
- Changes must be minimal and must not alter pricing, filtering, ranking, Discord notifications, or AtomPub posting behavior.

### Description
- Enhanced `pick_best_image_url(item)` to perform a first-hit, recursive extraction that accepts string/dict/list shapes and checks additional candidate keys (`imageUrl`, `itemImageUrl`, `itemImageUrls`) while preserving priority order (`mediumImageUrls` → `smallImageUrls` → fallbacks). 
- All extracted URLs are run through the existing `normalize_image_url()` which enforces `https`, fixes `//` prefixes, and adds/replaces `_ex=600x600` to prefer high-resolution images. 
- The `compute_offer()` path already calculates `image_url = pick_best_image_url(item)` and sets `OfferRow(image_url=...)`, so that assignment is preserved and now benefits from the improved extraction. 
- Existing logging behavior is retained: an INFO log is printed when the selected best offer has an image URL and a WARNING when it is empty, and the Hatena markdown hero image is emitted only when `best_offer.image_url` is present (no fallback text block is produced when missing).

### Testing
- Ran syntax check with `python -m py_compile main.py`, which succeeded. 
- No other automated tests exist in the repository; runtime behavior should be verified in CI by checking Action logs for `INFO selected best_offer.image_url canonical_id=... url=...` entries and the generated Hatena markdown for the hero image line when images are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f54292488330b97201b5e20b437d)